### PR TITLE
Fix for chmod use in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,14 +166,11 @@ tasks.withType(Copy) {
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
-tasks.withType(JavaCompile) {
-    options.encoding = 'UTF-8'
-    options.compilerArgs += [
-        '--add-exports', 'javafx.graphics/com.sun.javafx.css=ALL-UNNAMED',
-        '--add-exports', 'javafx.graphics/com.sun.javafx.scene.input=ALL-UNNAMED',
-        '--add-exports', 'javafx.graphics/com.sun.javafx.util=ALL-UNNAMED',
-        '--add-exports', 'javafx.controls/com.sun.javafx.scene.control.skin.resources=ALL-UNNAMED',
-        '--add-exports', 'javafx.controls/com.sun.javafx.scene.control.behavior=ALL-UNNAMED'
-        // (optionally keep the --add-opens lines if you also run tests here)
-    ]
-}
+
+
+
+
+
+
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -166,11 +166,14 @@ tasks.withType(Copy) {
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
-
-
-
-
-
-
-
-
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+    options.compilerArgs += [
+        '--add-exports', 'javafx.graphics/com.sun.javafx.css=ALL-UNNAMED',
+        '--add-exports', 'javafx.graphics/com.sun.javafx.scene.input=ALL-UNNAMED',
+        '--add-exports', 'javafx.graphics/com.sun.javafx.util=ALL-UNNAMED',
+        '--add-exports', 'javafx.controls/com.sun.javafx.scene.control.skin.resources=ALL-UNNAMED',
+        '--add-exports', 'javafx.controls/com.sun.javafx.scene.control.behavior=ALL-UNNAMED'
+        // (optionally keep the --add-opens lines if you also run tests here)
+    ]
+}

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,11 @@ ext {
 ext.depver = { name -> project.ext.versionsMap[name] }
 
 tasks.create(name: 'gitExecutableHooks').doLast {
-    Runtime.getRuntime().exec("chmod -R +x .git/hooks/");
+    if (System.getProperty('os.name').toLowerCase().contains('windows')) {
+        logger.lifecycle('Skipping chmod on Windows')
+    } else {
+        Runtime.getRuntime().exec("chmod -R +x .git/hooks/")
+    }
 }
 
 task installGitHooks(type: Copy) {


### PR DESCRIPTION
Fix for chmod use in build.gradle.
The command can be ignored when building in Windows.